### PR TITLE
added %header magic to prepend sparql query with some aritrary command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,14 @@ value::
   %qparam <name>
 
 
+``%header``
+............
+Adds a certain header to each sparql queries. This can be used to set some 
+(potentially non SPARQL) command in the query. For instance virtuoso endpoints 
+accept the _define_ keyword which can be used to trigger the server reasoner.
+
+
+
 ``%auth``
 ...........
 

--- a/sparqlkernel/connection.py
+++ b/sparqlkernel/connection.py
@@ -55,6 +55,7 @@ magics = {
     '%endpoint' : [ '<url>', 'set SPARQL endpoint. **REQUIRED**'],
     '%auth':      ['(basic|digest) <username> <passwd>', 'send HTTP authentication'],
     '%qparam' :   [ '<name> [<value>]', 'add (or delete) a persistent custom parameter to the endpoint query'],
+    '%header' :   [ '<value>', 'set (or delete) a persistent header to all queries (precedes all other lines of the SPARQL query)'],
     '%prefix' :   [ '<name> [<uri>]', 'set (or delete) a persistent URI prefix for all queries'],
     '%graph' :    [ '<uri>', 'set default graph for the queries' ],
     '%format' :   [ 'JSON | N3 | XML | any | default', 'set requested result format' ],
@@ -374,7 +375,7 @@ class SparqlConnection( object ):
         self.log = logger or logging.getLogger(__name__)
         self.srv = None
         self.log.info( "START" )
-        self.cfg = CfgStruct( pfx={}, lmt=20, fmt=None, out=None, aut=None,
+        self.cfg = CfgStruct( header={}, pfx={}, lmt=20, fmt=None, out=None, aut=None,
                               grh=None, dis='table', typ=False, lan=[], par={} )
 
     def magic( self, line ):
@@ -521,8 +522,19 @@ class SparqlConnection( object ):
             except ValueError:
                 raise KrnlException( 'unknown log level: {}', param )
 
+        elif cmd == 'header':
+            v = param.split(None, 1)
+            if len(v) == 0:
+                raise KrnlException("missing %header value")
+            elif len(v) == 1:
+                self.cfg.header.pop(v[0], None)
+                return ['header deleted: {}', v[0]], 'magic'
+            else:
+                self.cfg.header[v[0]] = v[1]
+                return ['header set: {} = {}'] + v, 'magic'
+
         else:
-            raise KrnlException( "magic not found: {}", cmd )
+                raise KrnlException( "magic not found: {}", cmd )
 
 
     def query( self, query, num=0, silent=False ):
@@ -532,11 +544,18 @@ class SparqlConnection( object ):
         if self.srv is None:
             raise KrnlException('no endpoint defined')             
 
-        # Prepend to the query all predefined SPARQL prefixes
+        # Add to the query all predefined SPARQL prefixes
         if self.cfg.pfx:
-            prefix = '\n'.join( ( 'PREFIX {} {}'.format(*v) 
+            prefix = '\n'.join( ( 'PREFIX {} {}'.format(*v)
                                   for v in self.cfg.pfx.items() ) )
             query = prefix  + '\n' + query
+
+        # Prepend to the query all predefined Header entries
+        # The header should be before the prefix and other sparql commands
+        if self.cfg.header:
+            header = '\n'.join( ( '{}'.format(v[1])
+                                  for v in self.cfg.header.items() ) )
+            query = header  + '\n' + query
 
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug( "\n%50s%s", query, '...' if len(query)>50 else '' )


### PR DESCRIPTION
Hi there!

I have been using the sparql kernel for some times and am very happy with it.

I only started to have some issued with it when I started to make use of the virtuoso inference commands with our local virtuoso sparql entry point.
Basically virtuoso (7.2.x) expects then the sparql query to be prepended with some (non SPARQL command): DEFINE. For instance:
>DEFINE input:inference 'http://www.w3.org/2002/07/owl#'
This line must be the first of the query. 

As a result, things work as long as no %prefix was set (the first line of the query is indeed the DEFINE... line) but things stop working as soon as one or several %prefix were defines (the query is prepended with the PREFIX keyword and the whole query is invalid as the DEFINE thing ends up after the PREFIX line(s)).

So I thought the easiest would be to define an extra %HEADER magic, which allows to add some raw text to the query, and this one is added before the prefix lines.

I made fairly quickly the modifications but on my local installation it seems to work well. I tested only with python 3 though.