### PR TITLE
Change comment separator character from # to ##

### DIFF
--- a/sparqlkernel/kernel.py
+++ b/sparqlkernel/kernel.py
@@ -143,7 +143,7 @@ class SparqlKernel(Kernel):
 
         # Split lines and remove empty lines & comments
         code_noc = [line.strip() for line in code.split('\n')
-                    if line and line[0] != '#']
+                    if line and line[0] != '##'] # changed # to ##. cf many uris in obofoundry do use '#' as char.
         if not code_noc:
             return self._send(None)
 


### PR DESCRIPTION
Hello,

This is a proposition for an update of the seprator character for comments (within sparql queries) from # to ##. I guess the main issue is that # is in general is accepted as a valid character in uris for sparql queries (and generically in rdf).
The problem is acute with the many ontologies of the obofoundry foundation which are ubiquitous in the life science/biomedical world, as until not so long ago they encouraged the use of # as part of the official uris and many of these uris are still around.

The only option to comply strictly would be to remove comments, ie. one could create a magic to deactivate comments for the queries involving uris with # characters.

Still adding comments to queries it is a very convenient feature, so maybe one could update the comment separator from '#' to '##' ?
I understand this is a backward incompatible change which one might want to reject.
