### PR TITLE
.itervalues() => .values() python3 compatibility

### DIFF
--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -148,7 +148,7 @@ def label(x, gr, preferred_languages=None):
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return labels.values().next()
+        return next(iter(labels.values()))
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:

--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -148,7 +148,7 @@ def label(x, gr, preferred_languages=None):
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return labels.itervalues().next()
+        return labels.values().next()
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:


### PR DESCRIPTION
not sure how to target compatibility for both python2 and python3 since the drawbacks of using `.values()` in python2 are obvious. otherwise, this is a patch for python3.