### PR TITLE
Bugfix: Python3 incompatibility in drawgraph.py (Python 2.7 compatible)

### DIFF
--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -148,7 +148,7 @@ def label(x, gr, preferred_languages=None):
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return labels.itervalues().next()
+        return next(iter(labels.values()))
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:


### PR DESCRIPTION
Graph display mode (`%display diagram`) will not work with Python 3; the syntax used in this fix will also work on Python 2.7. 

Fixes issue [Diagram does not work with python 3](https://github.com/paulovn/sparql-kernel/issues/31)