### PR TITLE
feat/1.3.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
+v. 1.3.0
+* improved error messages on HTTP errors
+* strip whitespace in all lines, including comment lines (@gpotdevin)
+* added new magics: %method (@alexisdimi), %http_header
+* added new option `none` to %format magic
+
 v. 1.2.1
-* bugfix (@blake-regalia): in label selection for graph nodes,  itervalues() does not exist in python3
+* bugfix (@blake-regalia, @alexisdimi): in label selection for graph nodes, itervalues() does not exist in python3
 * keep order in preferred languages
 * PEP8 reformatting
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+v. 1.2.1
+* bugfix (@blake-regalia): in label selection for graph nodes,  itervalues() does not exist in python3
+* keep order in preferred languages
+* PEP8 reformatting
+
 v. 1.2.0
 * added %header magic (by gpotdevin)
 * fixed JSON format for raw format (reported by BoPeng)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,11 @@
 v. 1.3.0
 * improved error messages on HTTP errors
 * strip whitespace in all lines, including comment lines (@gpotdevin)
-* added new magics: %method (@alexisdimi), %http_header
-* added new option `none` to %format magic
+* added new magics: %method (@alexisdimi), %http_header, %load
+* added new option `none` to %format magic, for manual control of format request
+* can read `%auth` parameters from environment variables
+* do not print out password for `%auth` magic
+* magic processing split out to magics.py
 
 v. 1.2.1
 * bugfix (@blake-regalia, @alexisdimi): in label selection for graph nodes, itervalues() does not exist in python3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# Build the Python source package & upload to PyPi
+
+# Package version: taken from the __init__.py file
+PKGNAME_BASE_UND := $(subst -,_,$(PKGNAME_BASE))
+VERSION_FILE := sparqlkernel/constants.py
+VERSION	     := $(shell grep __version__ $(VERSION_FILE) | sed -r "s/__version__ = '(.*)'/\1/")
+
+PKG := dist/sparqlkernel-$(VERSION).tar.gz
+
+# ----------------------------------------------------------------------------
+
+all:
+	python setup.py sdist
+
+clean:
+	rm -f $(PKG)
+
+install: all
+	pip install --upgrade $(PKG)
+
+reinstall: clean install
+
+# ----------------------------------------------------------------------------
+
+upload: all
+	twine upload $(PKG)
+	# python setup.py sdist --formats=gztar upload
+
+upload-test: all
+	twine upload -r pypitest $(PKG)
+
+

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 The kernel has only been tried with Jupyter 4.x. It works with Python 2.7 and
-Python 3 (tested with Python 3.5).
+Python 3 (tested with Python 3.6).
 
 The above mentioned `SPARQLWrapper`_ & `rdflib`_ Python packages are required
 dependencies (they are marked as such, so they will automatically be installed
@@ -82,142 +82,44 @@ keywords have contextual help, as of now.
 It also installs menu entries in the HELP menu pointing to SPARQL documentation.
 
 
-Output format
--------------
+Execution
+---------
 
 The query results are displayed in the notebook as cell results; there are a 
 number of choices for the display format, controlled via magics (see below).
 
-Each SPARQL query is immediately launched, once the results are printed out it 
+Each SPARQL query is immediately launched, and once the results are printed out it 
 is forgotten. Cells are thus completely independent from each other (except for
 magics, which are persistent).
+
+When a notebook is fully executed (e.g. *Cells* -> *Run all*), all code cells
+in the notebook, and hence all queries, are executed in sequence. To avoid
+execution of any particular cell, its type can be changed to RAW cell instead of
+CODE cell (in *Cells* -> *Cell Type* -> *Raw*).
 
 
 Magics
 ------
 
-A number of line magics (lines starting with ``%``) can be used to control the 
-kernel behaviour. These line magics must be placed at the start of the cell, 
-and there can be more than one per cell.
-Valid combinations are thus:
-
-* a cell with only a SPARQL query,
-* a cell consisting only of magics,
-* and a cell containing both magics and then a SPARQL query (but after the 
-  first SPARQL keyword the cell is assumed to be in SPARQL mode, and line 
-  magics will *not* be recognized as such).
-
-Comment lines (lines starting with ``#``) can be freely interspersed between 
-line magics or SPARQL queries.
-
-Magics also feature autocompletion and contextual help. Furthermore, there is 
-a special magic ``%lsmagics``; when executed on a cell it will output the list 
-of all currently available magics. The same info can be obtained by requesting
-contextual help (i.e. Shift-TAB) on a line containing only a percent sign.
-
-A few of the most relevant magics are explained in the following sections. The 
-complete set is always available in the notebook, by using the help or 
-autocompletion features.
+The kernel behaviour can be controlled by the use of line magics (lines
+starting with ``%``). See the `magics documentation`_ for details.
 
 
-``%endpoint``
-.............
+Logging
+-------
 
-This magic is special in the sense that it is compulsory: there needs to be an 
-endpoint defined *before* the first SPARQL query is launched, otherwise the 
-query will fail.
+Settings defined by magics are always printed out in the cell result area
+(in red type) to inform what are the conditions in which a query is
+sent. Additionally, it is possible write logs that contain additional debug
+information.
 
-Its syntax is::
+The logging level is controlled by the ``%log`` magic. All logs are written to
+a single file, with the name ``sparqlkernel.log``. Its default place is the
+machine temporal directory (e.g. ``/tmp`` in Linux, or ``C:/TMP`` in Windows).
+There are two possibilities to change its location:
 
-    %endpoint <url>
-
-and it simply defines the SPARQL endpoint for all subsequent queries. 
-It remains active until superseded by another ``%endpoint`` magic.
-
-
-``%qparam``
-...........
-
-Define a custom additional parameter to be sent with every query. Its syntax
-is::
-
-  %qparam <name> <value>
-
-and it will add the ``name=value`` parameter to every subsequent query (it can
-be used e.g. to send API keys, or any parameter required by the endpoint).
-
-Any number of parameters can be defined; they will all be added to the queries
-executed after their definitions. To remove a parameter, use a line with no
-value::
-
-  %qparam <name>
-
-
-``%header``
-............
-Adds a certain header to each sparql queries. This can be used to set some 
-(potentially non SPARQL) command in the query. For instance virtuoso endpoints 
-accept the _define_ keyword which can be used to trigger the server reasoner.
-
-
-
-``%auth``
-...........
-
-Define HTTP authentication to send to the backend. Its syntax is::
-
-   %auth (basic | digest) <username> <password>
-
-Once defined, it will be sent to the backend on every subsequent query. To
-remove a defined authentication, just use::
-
-   %auth none
-
-  
-``%format``
-............
-
-Sets the data format requested to the SPARQL endpoint::
-
-    %format JSON | XML | N3  | any | default
-
-where:
-
-* ``JSON`` requests *application/sparql-results+json* format
-* ``XML`` requests *application/sparql-results+xml* format
-* ``N3`` requests the endpoint to provide results in *text/rdf+n3* format
-* ``any`` lets the endpoint return any format it pleases (note that if the
-  returned format is not JSON, XML or N3, it will be rendered as raw text)
-* ``default`` selects a default format depending on the requested SPARQL
-  operation (N3 for ``DESCRIBE`` and ``CONSTRUCT``, JSON for ``SELECT``, *any*
-  for the rest)
-
-
-``%display``
-............
-
-Sets the output rendering shape::
-
-    %display raw | table [withtypes] | diagram [svg|png] [withliterals]
-
-There are three possible display formats:
-
-* ``raw`` outputs the literal text returned by the SPARQL endpoint, in the
-  format that was requested (see ``%format`` magic)
-* ``table`` generates a table with the result. The optional ``withtypes``
-  modifier adds to each column an additional column that shows the data
-  type for each value
-* ``diagram`` takes the RDF graph returned (makes sense only for N3 result
-  format) and generates an image with a rendering of the graph. For it to
-  work, the ``dot`` program from GraphViz must be available in the search path.
-  The modifier selects the image format. Default is SVG, which usually works
-  much better (PNG quality is lower, image size is fixed and cannot contain
-  hyperlinks).
-
-Default is ``table``. Note that if the result format is not a supported format
-for a table or diagram representation (i.e. it is not JSON/XML or N3), then raw
-format will be used.
-
+* When installing the kernel, use the ``--logdir <dir>`` option
+* Before starting Jupyter, define the ``LOGDIR`` environment variable.
 
 
 
@@ -227,3 +129,4 @@ format will be used.
 .. _rdflib: https://github.com/RDFLib/rdflib
 .. _Graphviz: http://www.graphviz.org/
 .. _online Notebook viewer: http://nbviewer.jupyter.org/github/paulovn/sparql-kernel/blob/master/examples/
+.. _magics documentation: doc/magics.rst

--- a/doc/magics.rst
+++ b/doc/magics.rst
@@ -63,6 +63,18 @@ Set logging level. Available levels are: *critical*, *error*,  *warning*,
 *info*, *debug*.
 
 
+``%load``
+---------
+
+Open a file containing magic lines, read them and process them. Syntax is just::
+
+  %load <filename>
+
+and the file can contain only magic lines (full magics, starting with ``%``),
+or empty/comment lines.
+
+  
+
 2. Request creation
 ===================
 
@@ -172,6 +184,20 @@ remove a defined authentication, just use::
 
    %auth none
 
+Either of the three components of the authentication (*method*, *user*, *password*)
+can be read from environment variables, by using the ``env:`` prefix. E.g.::
+
+  %auth basic env:ENDPOINT_USERNAME env:ENDPOINT_PASSWD
+
+will use basic authentication, reading the username from the environment
+variable ``ENDPOINT_USERNAME`` and the password from the environment variable
+``ENDPOINT_PASSWD``. This allows keeping credentials out of the notebook
+(another way would be to use the ``%load`` magic).
+
+Note that, when printing out magic evaluation in the notebook, the password is
+never shown.
+
+
 
 3. Query formulation
 ====================
@@ -180,7 +206,7 @@ remove a defined authentication, just use::
 ``%prefix``
 -----------
 
-Set a URI prefix for all subsequent queries. Its syntax is::
+Define a URI prefix available for all subsequent queries. Its syntax is::
 
   %prefix <name> <uri>
 
@@ -199,14 +225,14 @@ Set the default graph for all queries, as::
 
   %graph <uri>
 
-It is equivalent to using the ``FROM`` SPARQL keyword in a query, but when it
-is defined is automatically sent in all queries.
+It is equivalent to using the ``FROM`` SPARQL keyword in a query, but when
+defined it is automatically sent in all queries.
 
 
 ``%header``
 -----------
 
-Prepends a certain textual header line to all sparql queries. This can be used
+Prepends a certain textual header line to all SPARQL queries. This can be used
 to set some (potentially non SPARQL) command in the query.
 
 For instance Virtuoso endpoints accept the *DEFINE* keyword which can be used
@@ -273,8 +299,12 @@ Default is 20. It is also possible to use::
 ``%lang``
 ---------
 
-Selects the language chosen for the RDF labels, in either the *table* or the
+Selects the language(s) preferred for the RDF labels, in either the *table* or the
 *diagram* formats
+
+Syntax is::
+
+  %lang <lang> [...] | default | all
 
 
 ``%outfile``

--- a/doc/magics.rst
+++ b/doc/magics.rst
@@ -1,0 +1,307 @@
+SPARQL kernel magics
+********************
+
+A number of line magics (lines starting with ``%``) can be used to control the 
+kernel behaviour. These line magics must be placed at the start of the cell, 
+and there can be more than one per cell.
+Valid combinations are thus:
+
+* a cell with only a SPARQL query,
+* a cell consisting only of magics,
+* and a cell containing both magics and then a SPARQL query (but after the 
+  first SPARQL keyword the cell is assumed to be in SPARQL mode, and line 
+  magics will *not* be recognized as such).
+
+Comment lines (lines starting with ``#``) can be freely interspersed between 
+line magics or SPARQL queries.
+
+Magics also feature autocompletion and contextual help. Furthermore, there is 
+a special magic ``%lsmagics``; when executed on a cell it will output the list 
+of all currently available magics. The same info can be obtained by requesting
+contextual help (i.e. Shift-TAB) on a line containing only a percent sign.
+
+Magics are explained in the following sections (the most up-to-date set is
+always available inside the notebook, by using the help or autocompletion
+features). In the format specification, a string inside angle brackets,
+e.g. ``<string>`` refers to an arbitrary string; all else are literal strings
+that must be written as is.
+
+A magic sets persistent behaviour: once the cell containing the magic is
+executed, it is active for all subsequent SPARQL executions.
+
+
+1. General
+==========
+  
+``%endpoint``
+-------------
+
+This magic is special in the sense that it is compulsory: there needs to be an 
+endpoint defined *before* the first SPARQL query is launched, otherwise the 
+query will fail.
+
+Its syntax is::
+
+    %endpoint <url>
+
+and it simply defines the SPARQL endpoint for all subsequent queries. 
+It remains active until superseded by another ``%endpoint`` magic.
+
+
+
+``%lsmagics``
+-------------
+
+List all available magics with its syntax and a short description
+
+
+
+``%log``
+--------
+
+Set logging level. Available levels are: *critical*, *error*,  *warning*,
+*info*, *debug*.
+
+
+2. Request creation
+===================
+
+
+``%format``
+-----------
+
+Sets the data format requested to the SPARQL endpoint::
+
+    %format JSON | XML | N3  | any | default | none
+
+where:
+
+* ``JSON`` requests JSON format (*application/sparql-results+json* or equivalent)
+* ``XML`` requests XML format (*application/sparql-results+xml*)
+* ``N3`` requests the endpoint to provide results in *text/rdf+n3* format
+* ``any`` lets the endpoint return any format it pleases, by sending multiple
+  accepted formats (note that if the returned format is not JSON, SPARQL-XML
+  or N3, it will be rendered as raw text)
+* ``default`` selects a default format depending on the requested SPARQL
+  operation (N3 for ``DESCRIBE`` and ``CONSTRUCT``, JSON for ``SELECT``, *any*
+  for the rest)
+* ``none`` removes any format indication from the query parameters, leaving it
+  all to content negotiation.    
+
+Note that format specification for SPARQL endpoints is tricky, since there is
+no real standard for it. This is resolved via `SPARQLWrapper`_, which does two
+things simultaneously:
+
+* sends three query parameters ``format``, ``output`` and ``results`` with the
+  desired format
+* adds an HTTP *Accept* header with the accepted MIME type(s) for the requested
+  format
+
+
+Manual control
+..............
+
+The set of possible requested formats that can be used is limited by the
+validation code in SPARQLWrapper, so there might be an endpoint that demands
+a combination that cannot be set with the ``%format`` magic.
+
+As a workaround, if a particular endpoint needs a custom format specification,
+it might be solved by
+
+* setting ``%format`` to ``none`` (which will suppress the automatic format request
+  in the query parameters)
+* adding a manual ``%qparam <name> <format>`` magic with the needed format
+  specification, as requested by the endpoint
+* adding an ``%http_header Accept <type/subtype>`` magic with the desired accepted
+  MIME type(s)
+
+E.g., assuming the backend needs a ``result_format`` parameter in the query
+string, and that it should contain a MIME type, one possible set of magics
+would be::
+
+  %format none
+  %qparam result_format application/json
+  %http_header Accept application/json,application/sparql-results+json
+
+where we include in the *Accept* HTTP header all MIME types the endpoint might
+produce.
+  
+
+``%http_header``
+----------------
+
+Sends an arbitrary HTTP header to the endpoint. Its syntax is::
+
+  %http_header <name> <value>
+
+If ``<value>`` is not present, the existing HTTP header is removed for
+subsequent queries. The header name in ``<name>`` is case insensitive.
+
+Example::
+
+  %http_header Accept application/json
+
+
+``%qparam``
+-----------
+
+Defines a custom additional query parameter to be sent with every request. Its
+syntax is::
+
+  %qparam <name> <value>
+
+which will add the ``<name>=<value>`` parameter to every subsequent query (it can
+be used e.g. to send API keys, or any parameter required by the endpoint).
+
+Any number of parameters can be defined; they will all be added to the queries
+executed after their definitions. To remove a parameter, use a line with no
+value::
+
+  %qparam <name>
+
+  
+``%auth``
+---------
+
+Define HTTP authentication to send to the backend. Its syntax is::
+
+   %auth (basic | digest) <username> <password>
+
+Once defined, it will be sent to the backend on every subsequent query. To
+remove a defined authentication, just use::
+
+   %auth none
+
+
+3. Query formulation
+====================
+   
+
+``%prefix``
+-----------
+
+Set a URI prefix for all subsequent queries. Its syntax is::
+
+  %prefix <name> <uri>
+
+Its effect is the same as using the SPARQL ``PREFIX`` keyword, only that once
+defined it is automatically prepended to *all* queries in cells below it.
+
+To remove a prefix, use a magic without URI::
+
+  %prefix <name>
+
+
+``%graph``
+----------
+
+Set the default graph for all queries, as::
+
+  %graph <uri>
+
+It is equivalent to using the ``FROM`` SPARQL keyword in a query, but when it
+is defined is automatically sent in all queries.
+
+
+``%header``
+-----------
+
+Prepends a certain textual header line to all sparql queries. This can be used
+to set some (potentially non SPARQL) command in the query.
+
+For instance Virtuoso endpoints accept the *DEFINE* keyword which can be used
+to trigger the server reasoner.
+
+The syntax is::
+
+   %header <arbitrary line including spaces>
+
+Any number of header magics may be defined; each one defines an arbitrary line
+to be prepended to all SPARQL queries. They are sent *before* any defined
+``%PREFIX`` magics.
+
+The magic::
+
+  %header off
+
+removes all defined headers.
+
+
+
+4. Rendering
+============
+  
+
+``%display``
+------------
+
+Sets the output rendering shape::
+
+    %display raw | table [withtypes] | diagram [svg|png] [withliterals]
+
+There are three possible display shapes:
+
+* ``raw`` outputs the literal text returned by the SPARQL endpoint, in the
+  format that was requested (see ``%format`` magic)
+* ``table`` generates a table with the result. The optional ``withtypes``
+  modifier adds to each column an additional column that shows the data
+  type for each value
+* ``diagram`` takes the RDF graph returned (makes sense only for N3 result
+  format) and generates an image with a rendering of the graph. For it to
+  work, the ``dot`` program from GraphViz must be available in the search path.
+  The modifier selects the image format. Default is SVG, which usually works
+  much better (PNG quality is lower, image size is fixed and cannot contain
+  hyperlinks).
+
+Default is ``table``. Note that if the result format is not a supported format
+for a table or diagram representation (i.e. it is not JSON/XML or N3), then raw
+format will be used.
+
+
+``%show``
+---------
+
+Maximum number of results shown, as::
+
+   %show N
+
+Default is 20. It is also possible to use::
+    
+   %show all
+
+
+``%lang``
+---------
+
+Selects the language chosen for the RDF labels, in either the *table* or the
+*diagram* formats
+
+
+``%outfile``
+------------
+
+Saves the raw result of every query to a file::
+
+  %outfile <filename>
+
+Use a full path for the filename. If the name contains a `%d` part, it will be
+used to substitute the cell number, i.e. the magic::
+
+  %outfile /data/query-%03d.txt
+
+will save each executed query to files ``/data/query-001.txt``,
+``/data/query-002.txt``, etc.
+
+Using::
+
+  %outfile off
+
+will cancel file saving.
+  
+
+..  _SPARQL: https://www.w3.org/TR/sparql11-overview/
+.. _Jupyter wrapper Kernel: http://jupyter-client.readthedocs.io/en/latest/wrapperkernels.html
+.. _SPARQLWrapper: https://rdflib.github.io/sparqlwrapper/
+.. _rdflib: https://github.com/RDFLib/rdflib
+.. _Graphviz: http://www.graphviz.org/
+.. _online Notebook viewer: http://nbviewer.jupyter.org/github/paulovn/sparql-kernel/blob/master/examples/

--- a/sparqlkernel/constants.py
+++ b/sparqlkernel/constants.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 KERNEL_NAME = 'sparql'
 LANGUAGE = 'sparql'

--- a/sparqlkernel/constants.py
+++ b/sparqlkernel/constants.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.2.1'
+__version__ = '1.3.0'
 
 KERNEL_NAME = 'sparql'
 LANGUAGE = 'sparql'

--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -148,7 +148,7 @@ def label(x, gr, preferred_languages=None):
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return labels.values().next()
+        return next(iter(labels.values()))
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:

--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -3,7 +3,7 @@
 Convert an RDF graph into an image for displaying in the notebook, via GraphViz
 It has two parts:
   - conversion from rdf into dot language. Code based in rdflib.utils.rdf2dot
-  - rendering of the dot graph into an image. Code based on 
+  - rendering of the dot graph into an image. Code based on
     ipython-hierarchymagic, which in turn bases it from Sphinx
     See https://github.com/tkf/ipython-hierarchymagic
 
@@ -101,21 +101,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import errno
 import base64
-import collections
 import re
 from io import StringIO
 
-from IPython.core.display import display_png, display_svg
-import rdflib.tools.rdf2dot as r2d
 import rdflib
 
 from .utils import escape
+
+import logging
+LOG = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------------
 
 LABEL_PROPERTIES = [
     rdflib.RDFS.label,
-    rdflib.URIRef('http://schema.org/name'), 
+    rdflib.URIRef('http://schema.org/name'),
     rdflib.URIRef('http://www.w3.org/2000/01/rdf-schema#label'),
     rdflib.URIRef('http://www.w3.org/2004/02/skos/core#prefLabel'),
     rdflib.URIRef("http://purl.org/dc/elements/1.1/title"),
@@ -128,48 +128,51 @@ LABEL_PROPERTIES = [
 
 
 def label(x, gr, preferred_languages=None):
-    """
-      @param x : graph entity
+    '''
+      @param x: graph entity
       @param gr (Graph): RDF graph
-      @param preferred_languages (iterable)
+      @param preferred_languages (iterable): list of preferred language codes for
+        the labels.
 
     Return the best available label in the graph for the passed entity.
     If a set of preferred languages is given, try them in order. If none is
     found, an arbitrary language will be chosen
-    """
+    '''
     # Find all labels & their language
-    labels = { l.language : l
-               for labelProp in LABEL_PROPERTIES
-               for l in gr.objects(x,labelProp) }
+    labels = {l.language: l
+              for labelProp in LABEL_PROPERTIES
+              for l in gr.objects(x, labelProp)}
+    #LOG.debug("LABELS %s %s", labels, preferred_languages)
+    #return repr(preferred_languages) + repr(labels)
     if labels:
-        #return repr(preferred_languages) + repr(labels)
-        #return u'|'.join(preferred_languages) +  u' -> ' + u'/'.join( u'{}:{}'.format(*i) for i in labels.items() )
+        # Search the preferred language
         if preferred_languages is not None:
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return next(iter(labels.values()))
+        # If not found, return an arbitrary language
+        return labels.popitem()[1]
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:
-        return gr.namespace_manager.compute_qname(x)[2].replace('_',' ')
-    except:
+        return gr.namespace_manager.compute_qname(x)[2].replace('_', ' ')
+    except Exception:
         # Attempt to extract the trailing part of an URI
-        m = re.search( '([^/]+)$', x )
-        return m.group(1).replace('_',' ') if m else x
+        m = re.search('([^/]+)$', x)
+        return m.group(1).replace('_', ' ') if m else x
 
 
 
-def rdf2dot( g, stream, opts={} ):
-    """
+def rdf2dot(g, stream, opts={}):
+    '''
     Convert the RDF graph to DOT
     Write the dot output to the stream
-    """
+    '''
+    LOG.debug("RDF2DOT: %s", opts)
 
-    accept_lang = set( opts.get('lang',[]) )
+    accept_lang = opts.get('lang', [])
     do_literal = opts.get('literal')
     nodes = {}
-    links = []
 
     def node_id(x):
         if x not in nodes:
@@ -180,18 +183,18 @@ def rdf2dot( g, stream, opts={} ):
         try:
             q = g.compute_qname(x)
             return q[0] + ":" + q[2]
-        except:
+        except Exception:
             return x
 
-    def accept( node ):
-        if isinstance( node, (rdflib.URIRef,rdflib.BNode) ):
+    def accept(node):
+        if isinstance(node, (rdflib.URIRef, rdflib.BNode)):
             return True
         if not do_literal:
             return False
         return (not accept_lang) or (node.language in accept_lang)
 
 
-    stream.write( u'digraph { \n node [ fontname="DejaVu Sans,Tahoma,Geneva,sans-serif" ] ; \n' )
+    stream.write(u'digraph { \n node [ fontname="DejaVu Sans,Tahoma,Geneva,sans-serif" ] ; \n')
 
     # Write all edges. In the process make a list of all nodes
     for s, p, o in g:
@@ -209,25 +212,24 @@ def rdf2dot( g, stream, opts={} ):
         on = node_id(o)
 
         # add the link
-        q = qname(p,g)
+        q = qname(p, g)
         if isinstance(p, rdflib.URIRef):
-            opstr = u'\t%s -> %s [ arrowhead="open", color="#9FC9E560", fontsize=9, fontcolor="#204080", label="%s", href="%s", target="_other" ] ;\n' % (sn,on,q,p)
+            opstr = u'\t%s -> %s [ arrowhead="open", color="#9FC9E560", fontsize=9, fontcolor="#204080", label="%s", href="%s", target="_other" ] ;\n' % (sn, on, q, p)
         else:
-            opstr = u'\t%s -> %s [ arrowhead="open", color="#9FC9E560", fontsize=9, fontcolor="#204080", label="%s" ] ;\n'%(sn,on,q)
-        stream.write( opstr )
+            opstr = u'\t%s -> %s [ arrowhead="open", color="#9FC9E560", fontsize=9, fontcolor="#204080", label="%s" ] ;\n' % (sn, on, q)
+        stream.write(opstr)
 
     # Write all nodes
     for u, n in nodes.items():
-        lbl = escape( label(u,g,accept_lang), True )
+        lbl = escape(label(u, g, accept_lang), True)
         if isinstance(u, rdflib.URIRef):
-            opstr = u'%s [ shape=none, fontsize=10, fontcolor=%s, label="%s", href="%s", target=_other ] \n' % (n, 'blue', lbl, u )
+            opstr = u'%s [ shape=none, fontsize=10, fontcolor=%s, label="%s", href="%s", target=_other ] \n' % (n, 'blue', lbl, u)
         else:
-            opstr = u'%s [ shape=none, fontsize=10, fontcolor=%s, label="%s" ] \n' % (n, 'black', lbl )
-        stream.write( u"# %s %s\n" % (u, n) )
-        stream.write( opstr )
+            opstr = u'%s [ shape=none, fontsize=10, fontcolor=%s, label="%s" ] \n' % (n, 'black', lbl)
+        stream.write(u"# %s %s\n" % (u, n))
+        stream.write(opstr)
 
     stream.write(u'}\n')
-
 
 
 # ------------------------------------------------------------------------
@@ -236,13 +238,16 @@ EPIPE  = getattr(errno, 'EPIPE', 0)
 EINVAL = getattr(errno, 'EINVAL', 0)
 
 
-def run_dot( code, fmt='svg', gv_options=[], **kwargs ):
-
+def run_dot(code, fmt='svg', gv_options=[], **kwargs):
+    '''
+    Run GraphViz on the buffer holding the graph
+    '''
+    LOG.debug("rundot fmt=%s options=%s", fmt, gv_options)
     # mostly copied from sphinx.ext.graphviz.render_dot
     import os
     from subprocess import Popen, PIPE
 
-    dot_args = [ kwargs.get('prg','dot') ] + gv_options + ['-T', fmt ]
+    dot_args = [kwargs.get('prg', 'dot')] + gv_options + ['-T', fmt]
     if os.name == 'nt':
         # Avoid opening shell window.
         # * https://github.com/tkf/ipython-hierarchymagic/issues/1
@@ -278,34 +283,34 @@ def run_dot( code, fmt='svg', gv_options=[], **kwargs ):
 # ------------------------------------------------------------------------
 
 
-def draw_graph( g, fmt='svg', prg='dot', options={} ):
-    """
+def draw_graph(g, fmt='svg', prg='dot', options={}):
+    '''
     Draw an RDF graph as an image
-    """
+    '''
     # Convert RDF to Graphviz
     buf = StringIO()
-    rdf2dot( g, buf, options )
+    rdf2dot(g, buf, options)
 
-    gv_options = options.get('graphviz',[])
+    gv_options = options.get('graphviz', [])
     if fmt == 'png':
-        gv_options += [ '-Gdpi=220', '-Gsize=25,10!' ]
-        metadata = { "width": 5500, "height": 2200, "unconfined" : True }
+        gv_options += ['-Gdpi=220', '-Gsize=25,10!']
+        metadata = {"width": 5500, "height": 2200, "unconfined": True}
 
     #import codecs
     #with codecs.open('/tmp/sparqlkernel-img.dot','w',encoding='utf-8') as f:
     #    f.write( buf.getvalue() )
-    
+
     # Now use Graphviz to generate the graph
-    image = run_dot( buf.getvalue(), fmt=fmt, options=gv_options, prg=prg )
+    image = run_dot(buf.getvalue(), fmt=fmt, options=gv_options, prg=prg)
 
     #with open('/tmp/sparqlkernel-img.'+fmt,'w') as f:
     #    f.write( image )
 
     # Return it
     if fmt == 'png':
-        return { 'image/png' : base64.b64encode(image).decode('ascii') }, \
-               { "image/png" : metadata }
+        return {'image/png': base64.b64encode(image).decode('ascii')}, \
+               {'image/png': metadata}
     elif fmt == 'svg':
-        return { 'image/svg+xml' : image.decode('utf-8').replace('<svg','<svg class="unconfined"',1) }, \
-               { "unconfined" : True }
-
+        img = image.decode('utf-8').replace('<svg', '<svg class="unconfined"', 1)
+        return {'image/svg+xml': img}, \
+               {'unconfined': True}

--- a/sparqlkernel/drawgraph.py
+++ b/sparqlkernel/drawgraph.py
@@ -148,7 +148,7 @@ def label(x, gr, preferred_languages=None):
             for l in preferred_languages:
                 if l in labels:
                     return labels[l]
-        return labels.itervalues().next()
+        return labels.values().next()
 
     # No labels available. Try to generate a QNAME, or else, the string itself
     try:

--- a/sparqlkernel/kernel.py
+++ b/sparqlkernel/kernel.py
@@ -142,7 +142,8 @@ class SparqlKernel(Kernel):
         self._klog.info("[%.30s] [%d] [%s]", code, silent, user_expressions)
 
         # Split lines and remove empty lines & comments
-        code_noc = [line.strip() for line in code.split('\n')
+        code_noc = [line for line in
+                    map(lambda x: x.strip(), code.split('\n'))
                     if line and line[0] != '#']
         if not code_noc:
             return self._send(None)

--- a/sparqlkernel/kernel.py
+++ b/sparqlkernel/kernel.py
@@ -1,21 +1,22 @@
 """
-The main kernel class for Jupyter. 
+The main kernel class for Jupyter.
 Interact with the notebook and process all frontend requests.
 """
+
+import logging
 
 from ipykernel.kernelbase import Kernel
 from traitlets import List
 
-import logging
-
 import SPARQLWrapper
-from SPARQLWrapper.SPARQLExceptions import SPARQLWrapperException
 
 from .constants import __version__, LANGUAGE
-from .utils import is_collection, data_msg
+from .utils import data_msg
 from .setlogging import set_logging
 from .language import sparql_names, sparql_help
-from .connection import SparqlConnection, KrnlException, magics, magic_help
+from .connection import SparqlConnection
+from .magics import split_lines, process_magic, MAGICS, MAGIC_HELP
+
 # IPython.core.display.HTML
 
 
@@ -35,10 +36,10 @@ def token_at_cursor(code, pos=0):
     Find the token present at the passed position in the code buffer
      :return (tuple): a pair (token, start_position)
     """
-    l = len(code)
+    cl = len(code)
     end = start = pos
     # Go forwards while we get alphanumeric chars
-    while end < l and code[end].isalpha():
+    while end < cl and code[end].isalpha():
         end += 1
     # Go backwards while we get alphanumeric chars
     while start > 0 and code[start-1].isalpha():
@@ -142,9 +143,7 @@ class SparqlKernel(Kernel):
         self._klog.info("[%.30s] [%d] [%s]", code, silent, user_expressions)
 
         # Split lines and remove empty lines & comments
-        code_noc = [line for line in
-                    map(lambda x: x.strip(), code.split('\n'))
-                    if line and line[0] != '#']
+        code_noc = split_lines(code)
         if not code_noc:
             return self._send(None)
 
@@ -159,7 +158,7 @@ class SparqlKernel(Kernel):
 
             # Process magics. Once done, remove them from the query buffer
             if magic_lines:
-                out = [self._k.magic(line) for line in magic_lines]
+                out = [process_magic(line, self._k.cfg) for line in magic_lines]
                 self._send(out, 'multi', silent=silent)
                 code = '\n'.join(code_noc[len(magic_lines):])
 
@@ -189,17 +188,17 @@ class SparqlKernel(Kernel):
         if not is_magic(token, start, code):
             info = sparql_help.get(token.upper(), None)
         elif token == '%':
-            info = magic_help
+            info = MAGIC_HELP
         else:
-            info = magics.get(token, None)
+            info = MAGICS.get(token, None)
             if info:
                 info = '{} {}\n\n{}'.format(token, *info)
 
         return {'status': 'ok',
                 'data': {'text/plain': info},
                 'metadata': {},
-                'found': info is not None
-               }
+                'found': info is not None}
+
 
     # -----------------------------------------------------------------
 
@@ -212,7 +211,7 @@ class SparqlKernel(Kernel):
         token, start = token_at_cursor(code, cursor_pos)
         tkn_low = token.lower()
         if is_magic(token, start, code):
-            matches = [k for k in magics.keys() if k.startswith(tkn_low)]
+            matches = [k for k in MAGICS.keys() if k.startswith(tkn_low)]
         else:
             matches = [sparql_names[k] for k in sparql_names
                        if k.startswith(tkn_low)]
@@ -223,6 +222,7 @@ class SparqlKernel(Kernel):
                     'cursor_start': start,
                     'cursor_end': start+len(token),
                     'matches': matches}
+
 
 # -----------------------------------------------------------------
 

--- a/sparqlkernel/language.py
+++ b/sparqlkernel/language.py
@@ -31,14 +31,14 @@ sparql_keywords = [
     'SERVICE'
 ]
 
-sparql_operators = [ 'bound', 'isIRI', 'isBlank', 'isLiteral',
-                     'str', 'lang', 'datatype', 'sameTerm', 
-                     'langMatches', 'regex',  ]
+sparql_operators = ['bound', 'isIRI', 'isBlank', 'isLiteral',
+                    'str', 'lang', 'datatype', 'sameTerm',
+                    'langMatches', 'regex']
 
 
 # All SPARQL reserved words
 sparql_names = dict( ((k.lower(),k) for k in 
-                      chain.from_iterable( (sparql_keywords,sparql_operators))
+                      chain.from_iterable( (sparql_keywords, sparql_operators))
                   ) )
 
 # ------------------------------------------------------------------------

--- a/sparqlkernel/magics.py
+++ b/sparqlkernel/magics.py
@@ -1,0 +1,266 @@
+
+import os
+import os.path
+import io
+from operator import itemgetter
+import logging
+
+import SPARQLWrapper
+
+from .constants import DEFAULT_TEXT_LANG
+from .utils import KrnlException, is_collection
+
+
+# Maximum number of nestes magic files
+MAX_RECURSE = 10
+
+
+# The list of implemented magics with their help, as a pair [param,help-text]
+MAGICS = {
+    '%lsmagics': ['', 'list all magics'],
+    '%load': ['<filename>', 'load a file with magic lines and process them'],
+    '%endpoint': ['<url>', 'set SPARQL endpoint. **REQUIRED**'],
+    '%auth':     ['(basic|digest|none) <username> <passwd>', 'send HTTP authentication (use env:<var> to get values from environment variables)'],
+    '%qparam':   ['<name> [<value>]', 'add (or delete) a persistent custom parameter to all queries'],
+    '%http_header':   ['<name> [<value>]', 'add (or delete) an arbitrary HTTP header to all queries'],
+    '%prefix':   ['<name> [<uri>]', 'set (or delete) a persistent URI prefix for all queries'],
+    '%header':   ['<string> | OFF', 'add a persistent SPARQL header line before all queries, or delete all defined headers'],
+    '%graph':    ['<uri>', 'set default graph for the queries'],
+    '%format':   ['JSON | N3 | XML | default | any | none', 'set requested result format'],
+    '%display':  ['raw | table [withtypes] | diagram [svg|png] [withliterals]',
+                  'set display format'],
+    '%lang':     ['<lang> [...] | default | all',
+                  'language(s) preferred for labels'],
+    '%show':     ['<n> | all',
+                  'maximum number of shown results'],
+    '%outfile':  ['<filename> | off', 'save raw output to a file (use "%d" in name to add cell number, "off" to cancel saving)'],
+    '%log':      ['critical | error | warning | info | debug',
+                  'set logging level'],
+    '%method':   ['get | post', 'set HTTP method'],
+}
+
+
+# The full list of all magics
+MAGIC_HELP = ('Available magics:\n' +
+              '  '.join(sorted(MAGICS.keys())) +
+              '\n\n' +
+              '\n'.join(('{0} {1} : {2}'.format(k, *v)
+                         for k, v in sorted(MAGICS.items(), key=itemgetter(0)))))
+
+
+# -----------------------------------------------------------------------------
+
+def split_lines(buf):
+    '''
+    Split a buffer in lines, skipping emtpy lines and commend lines, and
+    stripping whitespace at the beginning or end of lines
+    '''
+    return [line for line in map(lambda x: x.strip(), buf.split('\n'))
+            if line and line[0] != '#']
+
+
+def process_magic(line, cfg, _recurse=0):
+    """
+    Read and process magics
+      @param line (str): the full line containing a magic
+      @param obj
+      @return (list): a tuple (output-message,css-class), where
+        the output message can be a single string or a list (containing
+        a Python format string and its arguments)
+    """
+    if _recurse > MAX_RECURSE:
+        raise KrnlException('maximum magic file recursion level exceeded')
+
+    # The %lsmagic has no parameters
+    if line.startswith('%lsmagic'):
+        return MAGIC_HELP, 'magic-help'
+
+    # Split line into command & parameters
+    try:
+        cmd, param = line.split(None, 1)
+    except ValueError:
+        raise KrnlException("invalid magic line: {}", line)
+    cmd = cmd[1:].lower()
+
+    # Process each magic
+    if cmd == 'load':
+
+        try:
+            with io.open(param, 'rt', encoding='utf-8') as f:
+                buf = f.read()
+        except Exception as e:
+            raise KrnlException("cannot read magics file '{}': {}", param, e)
+        for line in split_lines(buf):
+            if line[0] != '%':
+                raise KrnlException("error in file '{}': non-magic line found: {}",
+                                    param, line)
+            process_magic(line, cfg, _recurse+1)
+
+    elif cmd == 'endpoint':
+
+        cfg.ept = param
+        return ['Endpoint set to: {}', param], 'magic'
+
+    elif cmd == 'auth':
+
+        auth_data = param.split(None, 2)
+        if auth_data[0].lower() == 'none':
+            cfg.aut = None
+            return ['HTTP authentication: None'], 'magic'
+        if auth_data and len(auth_data) != 3:
+            raise KrnlException("invalid %auth magic")
+        try:
+            auth_data = [os.environ[v[4:]] if v.startswith(('env:', 'ENV:')) else v
+                         for v in auth_data]
+        except KeyError as e:
+            raise KrnlException("cannot find environment variable: {}", e)
+        cfg.aut = auth_data
+        return ['HTTP authentication: method={}, user={}, passwd set',
+                auth_data[0], auth_data[1]], 'magic'
+
+    elif cmd == 'qparam':
+
+        v = param.split(None, 1)
+        if len(v) == 0:
+            raise KrnlException("missing %qparam name")
+        elif len(v) == 1:
+            cfg.par.pop(v[0], None)
+            return ['Param deleted: {}', v[0]], 'magic'
+        else:
+            cfg.par[v[0]] = v[1]
+            return ['Param set: {} = {}'] + v, 'magic'
+
+    elif cmd == 'http_header':
+
+        v = param.split(None, 1)
+        if len(v) == 0:
+            raise KrnlException("missing %http_header name")
+        elif len(v) == 1:
+            try:
+                del cfg.hhr[v[0]]
+                return ['HTTP header deleted: {}', v[0]], 'magic'
+            except KeyError:
+                return ['Not-existing HTTP header: {}', v[0]], 'magic'
+        else:
+            cfg.hhr[v[0]] = v[1]
+            return ['HTTP header set: {} = {}'] + v, 'magic'
+
+    elif cmd == 'prefix':
+
+        v = param.split(None, 1)
+        if len(v) == 0:
+            raise KrnlException("missing %prefix value")
+        elif len(v) == 1:
+            cfg.pfx.pop(v[0], None)
+            return ['Prefix deleted: {}', v[0]], 'magic'
+        else:
+            cfg.pfx[v[0]] = v[1]
+            return ['Prefix set: {} = {}'] + v, 'magic'
+
+    elif cmd == 'show':
+
+        if param == 'all':
+            cfg.lmt = None
+        else:
+            try:
+                cfg.lmt = int(param)
+            except ValueError as e:
+                raise KrnlException("invalid result limit: {}", e)
+        sz = cfg.lmt if cfg.lmt is not None else 'unlimited'
+        return ['Result maximum size: {}', sz], 'magic'
+
+    elif cmd == 'format':
+
+        fmt_list = {'JSON': SPARQLWrapper.JSON,
+                    'N3': SPARQLWrapper.N3,
+                    'XML': SPARQLWrapper.XML,
+                    'RDF': SPARQLWrapper.RDF,
+                    'NONE': None,
+                    'DEFAULT': True,
+                    'ANY': False}
+        try:
+            fmt = param.upper()
+            cfg.fmt = fmt_list[fmt]
+        except KeyError:
+            raise KrnlException('unsupported format: {}\nSupported formats are: {!s}', param, list(fmt_list.keys()))
+        return ['Request format: {}', fmt], 'magic'
+
+    elif cmd == 'lang':
+
+        cfg.lan = DEFAULT_TEXT_LANG if param == 'default' else [] if param == 'all' else param.split()
+        return ['Label preferred languages: {}', cfg.lan], 'magic'
+
+    elif cmd in 'graph':
+
+        cfg.grh = param if param else None
+        return ['Default graph: {}', param if param else 'None'], 'magic'
+
+    elif cmd == 'display':
+
+        v = param.lower().split(None, 2)
+        if len(v) == 0 or v[0] not in ('table', 'raw', 'graph', 'diagram'):
+            raise KrnlException('invalid %display command: {}', param)
+
+        msg_extra = ''
+        if v[0] not in ('diagram', 'graph'):
+            cfg.dis = v[0]
+            cfg.typ = len(v) > 1 and v[1].startswith('withtype')
+            if cfg.typ and cfg.dis == 'table':
+                msg_extra = '\nShow Types: on'
+        elif len(v) == 1:   # graph format, defaults
+            cfg.dis = ['svg']
+        else:               # graph format, with options
+            if v[1] not in ('png', 'svg'):
+                raise KrnlException('invalid graph format: {}', param)
+            if len(v) > 2:
+                if not v[2].startswith('withlit'):
+                    raise KrnlException('invalid graph option: {}', param)
+                msg_extra = '\nShow literals: on'
+            cfg.dis = v[1:3]
+
+        display = cfg.dis[0] if is_collection(cfg.dis) else cfg.dis
+        return ['Display: {}{}', display, msg_extra], 'magic'
+
+    elif cmd == 'outfile':
+
+        if param in ('NONE', 'OFF'):
+            cfg.out = None
+            return ['no output file'], 'magic'
+        else:
+            cfg.out = param
+            return ['Output file: {}', os.path.abspath(param)], 'magic'
+
+    elif cmd == 'log':
+
+        if not param:
+            raise KrnlException('missing log level')
+        try:
+            lev = param.upper()
+            parent_logger = logging.getLogger(__name__.rsplit('.', 1)[0])
+            parent_logger.setLevel(lev)
+            return ("Logging set to {}", lev), 'magic'
+        except ValueError:
+            raise KrnlException('unknown log level: {}', param)
+
+    elif cmd == 'header':
+
+        if param.upper() == 'OFF':
+            num = len(cfg.hdr)
+            cfg.hdr = []
+            return ['All headers deleted ({})', num], 'magic'
+        else:
+            if param in cfg.hdr:
+                return ['Header skipped (repeated)'], 'magic'
+            cfg.hdr.append(param)
+            return ['Header added: {}', param], 'magic'
+
+    elif cmd == 'method':
+
+        method = param.upper()
+        if method not in ('GET', 'POST'):
+            raise KrnlException('invalid HTTP method: {}', param)
+        cfg.mth = method
+        return ['HTTP method: {}', method], 'magic'
+
+    else:
+        raise KrnlException("magic not found: {}", cmd)

--- a/sparqlkernel/utils.py
+++ b/sparqlkernel/utils.py
@@ -2,8 +2,12 @@
 Miscellaneous utility functions
 """
 
+import sys
 import logging
-LOG = logging.getLogger( __name__ )
+LOG = logging.getLogger(__name__)
+
+if sys.version_info[0] > 2:
+    unicode = str
 
 # Default wrapping class for an output message
 HTML_DIV_CLASS = 'krn-spql'
@@ -19,27 +23,27 @@ def is_collection(v):
     """
     # The 2nd clause is superfluous in Python 2, but (maybe) not in Python 3
     # Therefore we use 'str' instead of 'basestring'
-    return hasattr(v,'__iter__') and not isinstance(v,str)
+    return hasattr(v, '__iter__') and not isinstance(v, str)
 
 
 
 # ----------------------------------------------------------------------
 
-def escape( x, lb=False ):
+def escape(x, lb=False):
     """
     Ensure a string does not contain HTML-reserved characters (including
     double quotes)
     Optionally also insert a linebreak if the string is too long
     """
-    # Insert a linebreak? Roughly around the middle of the string,
+    # Insert a linebreak? Roughly around the middle of the string
     if lb:
-        l = len(x)
-        if l >= 10:
-            l >>= 1                     # middle of the string
-            s1 = x.find( ' ', l )       # first ws to the right
-            s2 = x.rfind( ' ', 0, l )   # first ws to the left
+        tl = len(x)
+        if tl >= 10:
+            tl >>= 1                   # middle of the string
+            s1 = x.find(' ', tl)       # first ws to the right
+            s2 = x.rfind(' ', 0, tl)   # first ws to the left
             if s2 > 0:
-                s = s2 if s1<0 or l-s1 > s2-l else s1
+                s = s2 if s1 < 0 or tl-s1 > s2-tl else s1
                 x = x[:s] + '\\n' + x[s+1:]
             elif s1 > 0:
                 x = x[:s1] + '\\n' + x[s1+1:]
@@ -49,7 +53,7 @@ def escape( x, lb=False ):
 
 # ----------------------------------------------------------------------
 
-def div( txt, *args, **kwargs ):
+def div(txt, *args, **kwargs):
     """
     Create & return an HTML <div> element by wrapping the passed text buffer.
       @param txt (basestring): the text buffer to use
@@ -59,18 +63,18 @@ def div( txt, *args, **kwargs ):
         <div> element
     """
     if args:
-        txt = txt.format( *args )
-    css = kwargs.get('css',HTML_DIV_CLASS)
-    return u'<div class="{}">{!s}</div>'.format( css, txt )
+        txt = txt.format(*args)
+    css = kwargs.get('css', HTML_DIV_CLASS)
+    return u'<div class="{}">{!s}</div>'.format(css, txt)
 
 
-def data_msglist( msglist ):
+def data_msglist(msglist):
     """
-    Return a Jupyter display_data message, in both HTML & text formats, by 
+    Return a Jupyter display_data message, in both HTML & text formats, by
     joining together all passed messages.
 
       @param msglist (iterable): an iterable containing a list of tuples
-        (message, css_style)      
+        (message, css_style)
 
     Each message is either a text string, or a list. In the latter case it is
     assumed to be a format string + parameters.
@@ -79,16 +83,16 @@ def data_msglist( msglist ):
     for msg, css in msglist:
         if is_collection(msg):
             msg = msg[0].format(*msg[1:])
-        html += div( escape(msg).replace('\n','<br/>'), css=css or 'msg' )
+        html += div(escape(msg).replace('\n', '<br/>'), css=css or 'msg')
         txt += msg + "\n"
-    return { 'data': {'text/html' : div(html),
-                      'text/plain' : txt },
-             'metadata' : {} }
+    return {'data': {'text/html': div(html),
+                     'text/plain': txt},
+            'metadata': {}}
 
 
-def data_msg( msg, mtype=None ):
+def data_msg(msg, mtype=None):
     """
-    Return a Jupyter display_data message, in both HTML & text formats, by 
+    Return a Jupyter display_data message, in both HTML & text formats, by
     formatting a given single message. The passed message may be:
       * An exception (including a KrnlException): will generate an error message
       * A list of messages (with \c mtype equal to \c multi)
@@ -101,21 +105,21 @@ def data_msg( msg, mtype=None ):
         not passed, \c krn-error will be used for exceptions and \c msg for
         everything else
     """
-    if isinstance(msg,KrnlException):
+    if isinstance(msg, KrnlException):
         return msg()    # a KrnlException knows how to format itself
-    elif isinstance(msg,Exception):
+    elif isinstance(msg, Exception):
         return KrnlException(msg)()
     elif mtype == 'multi':
-        return data_msglist( msg )
+        return data_msglist(msg)
     else:
-        return data_msglist( [ (msg, mtype) ] )
+        return data_msglist([(msg, mtype)])
 
 
 # ----------------------------------------------------------------------
 
-class KrnlException( Exception ):
+class KrnlException(Exception):
     """
-    An exception for kernel errors. 
+    An exception for kernel errors.
 
     When called as a function, it will generate a Jupyter message
     to be sent to the frontend.
@@ -126,10 +130,10 @@ class KrnlException( Exception ):
                 msg = msg.format(*args)
             except UnicodeError:
                 pass
-        elif isinstance(msg,Exception):
+        elif isinstance(msg, Exception):
             msg = repr(msg)
-        super(KrnlException,self).__init__(msg)
-        LOG.warn( 'KrnlException: %s', self, exc_info=1 )
+        super(KrnlException, self).__init__(msg)
+        LOG.warn('KrnlException: %s', self, exc_info=1)
 
     def __call__(self):
         """
@@ -137,13 +141,12 @@ class KrnlException( Exception ):
         """
         try:
             msg = self.args[0]
-            html = div( div('<span class="title">Error:</span> ' + 
-                            escape(msg).replace('\n','<br/>'), 
-                            css="krn-error" ) )
-            return { 'data': {'text/html' : html,
-                              'text/plain' : 'Error: ' + msg },
-                     'metadata' : {} }
+            html = div(div('<span class="title">Error:</span> ' +
+                           escape(msg).replace('\n', '<br/>'),
+                           css="krn-error"))
+            return {'data': {'text/html': html,
+                             'text/plain': 'Error: ' + msg},
+                    'metadata': {}}
         except Exception as e:
-            return { 'data':  { 'text/plain' : u'Error: '+unicode(repr(e)) },
-                     'metadata' : {} }
-
+            return {'data': {'text/plain': u'Error: ' + unicode(repr(e))},
+                    'metadata': {}}


### PR DESCRIPTION
* improved error messages on HTTP errors
* strip whitespace in all lines, including comment lines (@gpotdevin)
* added new magics: `%method` (@alexisdimi), `%http_header`
* added new option `none` to `%format` magic
* bugfix (@blake-regalia, @alexisdimi): in label selection for graph nodes, _itervalues()_ does not exist in python3
* keep order in preferred languages
* PEP8 reformatting
* improved documentation (magics, mostly)
