### PR TITLE
Replace NoneType in escape method

### DIFF
--- a/sparqlkernel/utils.py
+++ b/sparqlkernel/utils.py
@@ -35,6 +35,9 @@ def escape(x, lb=False):
     double quotes)
     Optionally also insert a linebreak if the string is too long
     """
+    # Return an empty string if x is None
+    if x is None:
+        return ""
     # Insert a linebreak? Roughly around the middle of the string
     if lb:
         tl = len(x)


### PR DESCRIPTION
I think it is a good idea to escape the NoneType to an empty string. As `.replace()` will fail on it.

Fixes #43.